### PR TITLE
syscall_intercept: Use extra trampoline table by default

### DIFF
--- a/src/libsyscall_intercept/intercept_desc.c
+++ b/src/libsyscall_intercept/intercept_desc.c
@@ -486,9 +486,10 @@ search_padding(unsigned char *syscall_addr, unsigned char *used)
 static void
 allocate_trampoline_table(struct intercept_desc *desc)
 {
-	char *e = getenv("INTERCEPT_TRAMPOLINE");
+	char *e = getenv("INTERCEPT_NO_TRAMPOLINE");
 
-	desc->uses_trampoline_table = (e != NULL) && (e[0] != '0');
+	/* Use the extra trampoline table by default */
+	desc->uses_trampoline_table = (e == NULL) && (e[0] == '0');
 
 	if (!desc->uses_trampoline_table) {
 		desc->trampoline_table = NULL;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/nvml/41)
<!-- Reviewable:end -->
