### PR TITLE
syscall_intercept: Few changes based on static analyzer results

### DIFF
--- a/src/libsyscall_intercept/disasm_wrapper.c
+++ b/src/libsyscall_intercept/disasm_wrapper.c
@@ -151,7 +151,7 @@ intercept_disasm_next_instruction(struct intercept_disasm_context *context,
 {
 	(void) context;
 
-	struct intercept_disasm_result result;
+	struct intercept_disasm_result result = {0};
 	const unsigned char *start = code;
 	size_t size = (size_t)(context->end - code + 1);
 	uint64_t address = (uint64_t)code;

--- a/src/libsyscall_intercept/intercept_desc.c
+++ b/src/libsyscall_intercept/intercept_desc.c
@@ -117,6 +117,7 @@ static void
 allocate_jump_table(struct intercept_desc *desc)
 {
 	/* How many bytes need to be addressed? */
+	assert(desc->text_start < desc->text_end);
 	size_t bytes = (size_t)(desc->text_end - desc->text_start + 1);
 
 	/* Allocate 1 bit for each addressable byte */
@@ -290,7 +291,7 @@ crawl_text(struct intercept_desc *desc)
 {
 	unsigned char *code = desc->text_start;
 	unsigned char *padding_used = code;
-	struct intercept_disasm_result prevs[3];
+	struct intercept_disasm_result prevs[3] = {0};
 	unsigned has_prevs = 0;
 	struct intercept_disasm_context *context =
 	    intercept_disasm_init(desc->text_start, desc->text_end);

--- a/src/libsyscall_intercept/intercept_util.c
+++ b/src/libsyscall_intercept/intercept_util.c
@@ -127,7 +127,7 @@ intercept_setup_log(const char *path_base, const char *trunc)
 }
 
 static char *
-print_open_flags(char *buffer, long flags)
+print_open_flags(char *buffer, int flags)
 {
 	char *c = buffer;
 
@@ -200,7 +200,7 @@ print_open_flags(char *buffer, long flags)
 		 * raw number.
 		 * e.g.: "O_RDONLY | O_NONBLOCK | 0x9876"
 		 */
-		c += sprintf(c, "0x%lx", flags);
+		c += sprintf(c, "0x%dx", flags);
 	} else if (c != buffer) {
 		/*
 		 * All bits in flag were parsed, and the pointer c does not
@@ -921,7 +921,7 @@ intercept_logs(const char *str)
 	size_t len = strlen(str) + 1;
 	char buffer[len];
 
-	strcpy(buffer, str);
+	strncpy(buffer, str, len);
 	buffer[len - 1] = '\n';
 
 	if (log_fd >= 0)
@@ -1032,7 +1032,7 @@ print_syscall(char *b, const char *name, unsigned args, ...)
 			const char *data = va_arg(ap, char *);
 			b = xprint_escape(b, data, 0x80, false, size);
 		} else if (format == F_OPEN_FLAGS) {
-			b = print_open_flags(b, va_arg(ap, long));
+			b = print_open_flags(b, va_arg(ap, int));
 		} else if (format == F_FCNTL_CMD) {
 			b = print_fcntl_cmd(b, va_arg(ap, long));
 		}

--- a/src/libsyscall_intercept/patcher.c
+++ b/src/libsyscall_intercept/patcher.c
@@ -71,7 +71,9 @@
 #include "intercept.h"
 #include "intercept_util.h"
 #include "../libpmem/cpu.h"
+#include "util.h"
 
+#include <assert.h>
 #include <cpuid.h>
 #include <stdint.h>
 #include <syscall.h>
@@ -127,8 +129,7 @@ create_absolute_jump(unsigned char *from, void *to)
 	from[12] = d[6];
 	from[13] = d[7];
 
-	if (TRAMPOLINE_SIZE != 14)
-		xabort();
+	COMPILE_ERROR_ON(TRAMPOLINE_SIZE != 14);
 }
 
 /*
@@ -334,7 +335,7 @@ create_patch_wrappers(struct intercept_desc *desc)
 			if (length < JUMP_INS_SIZE) {
 				char buffer[0x1000];
 
-				int l = sprintf(buffer,
+				int l = snprintf(buffer, sizeof(buffer),
 					"unintercepted syscall at: %s 0x%lx\n",
 					desc->dlinfo.dli_fname,
 					patch->syscall_offset);
@@ -404,8 +405,27 @@ init_patcher(void)
 {
 	unsigned char *begin = &intercept_asm_wrapper_tmpl[0];
 
-	if (&intercept_asm_wrapper_end <= begin)
-		xabort();
+	assert(&intercept_asm_wrapper_end > begin);
+	assert(&intercept_asm_wrapper_prefix > begin);
+	assert(&intercept_asm_wrapper_postfix > begin);
+	assert(&intercept_asm_wrapper_call > begin);
+	assert(&intercept_asm_wrapper_return_and_no_syscall > begin);
+	assert(&intercept_asm_wrapper_return_and_syscall > begin);
+	assert(&intercept_asm_wrapper_return_jump > begin);
+	assert(&intercept_asm_wrapper_push_origin_addr > begin);
+	assert(&intercept_asm_wrapper_simd_save > begin);
+	assert(&intercept_asm_wrapper_simd_restore > begin);
+	assert(&intercept_asm_wrapper_mov_return_addr_r11_no_syscall > begin);
+	assert(&intercept_asm_wrapper_mov_return_addr_r11_syscall > begin);
+	assert(&intercept_asm_wrapper_mov_libpath_r11 > begin);
+	assert(&intercept_asm_wrapper_mov_phaddr_r11 > begin);
+	assert(&intercept_asm_wrapper_mov_ph2addr_r11 > begin);
+	assert(&intercept_asm_wrapper_mov_r11_stack_first_return_addr > begin);
+	assert(&intercept_asm_wrapper_push_stack_first_return_addr > begin);
+	assert(&intercept_asm_wrapper_simd_save_YMM_end >
+	    &intercept_asm_wrapper_simd_save_YMM);
+	assert(&intercept_asm_wrapper_simd_restore_YMM_end >
+	    &intercept_asm_wrapper_simd_restore_YMM);
 
 	tmpl_size = (size_t)(&intercept_asm_wrapper_end - begin);
 	o_prefix = &intercept_asm_wrapper_prefix - begin;


### PR DESCRIPTION
disasm_wrapper.c:211    Uninitialized Variable - possible
intercept_desc.c:333    Uninitialized Array - possible
patcher.c:337   Buffer Overflow in Unbound sprintf
patcher.c:410   NUM.OVERFLOW
intercept_util.c:924    MS.BANNED.COPY
intercept_desc.c:120    NUM.OVERFLOW
intercept_util.c:192    CWARN.BITOP.SIZE
patcher.c:130   Unreachable code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/nvml/45)
<!-- Reviewable:end -->
